### PR TITLE
Adding a way to specify main files for dependencies that don't have a…

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ package:
 plugins:
   - serverless-plugin-include-dependencies
 
+custom: 
+  serverless-plugin-include-dependencies:
+    'package-name': 'main.js'
+
 functions:
   foo:
     handler: src/handler/foo.handler

--- a/__tests__/fixtures/custom-dependency.js
+++ b/__tests__/fixtures/custom-dependency.js
@@ -1,0 +1,3 @@
+const validation = require('custom-dependencies');
+
+module.exports = validation;

--- a/__tests__/fixtures/custom-direct-dependency.js
+++ b/__tests__/fixtures/custom-direct-dependency.js
@@ -1,0 +1,3 @@
+const validation = require('custom-package');
+
+module.exports = validation;

--- a/__tests__/fixtures/custom-optional-dependency.js
+++ b/__tests__/fixtures/custom-optional-dependency.js
@@ -1,0 +1,3 @@
+const validation = require('custom-optional-dependencies');
+
+module.exports = validation;

--- a/__tests__/fixtures/custom-package/custom.js
+++ b/__tests__/fixtures/custom-package/custom.js
@@ -1,0 +1,3 @@
+
+module.exports.handler = () => "answer to life the universe and everything";
+

--- a/__tests__/fixtures/custom-package/package.json
+++ b/__tests__/fixtures/custom-package/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "custom-package",
+  "version": "1.0.0",
+  "description": "",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+  }
+}

--- a/__tests__/fixtures/node_modules/custom-dependencies/custom.js
+++ b/__tests__/fixtures/node_modules/custom-dependencies/custom.js
@@ -1,0 +1,3 @@
+
+module.exports.handler = () => "Time is an illusion. Lunchtime doubly so.";
+

--- a/__tests__/fixtures/node_modules/custom-dependencies/package.json
+++ b/__tests__/fixtures/node_modules/custom-dependencies/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "custom-dependencies",
+  "version": "1.0.0",
+  "description": "",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "main": "custom.js",
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "custom-package": "^1.0.0"
+  }
+}

--- a/__tests__/fixtures/node_modules/custom-optional-dependencies/custom.js
+++ b/__tests__/fixtures/node_modules/custom-optional-dependencies/custom.js
@@ -1,0 +1,3 @@
+
+module.exports.handler = () => "We demand rigidly defined areas of doubt and uncertainty.";
+

--- a/__tests__/fixtures/node_modules/custom-optional-dependencies/package.json
+++ b/__tests__/fixtures/node_modules/custom-optional-dependencies/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "custom-optional-dependencies",
+  "version": "1.0.0",
+  "description": "",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "main": "custom.js",
+  "author": "",
+  "license": "ISC",
+  "optionalDependencies": {
+    "custom-package": "^1.0.0"
+  }
+}

--- a/__tests__/fixtures/node_modules/custom-package/custom.js
+++ b/__tests__/fixtures/node_modules/custom-package/custom.js
@@ -1,0 +1,3 @@
+
+module.exports.handler = () => "answer to life the universe and everything";
+

--- a/__tests__/fixtures/node_modules/custom-package/package.json
+++ b/__tests__/fixtures/node_modules/custom-package/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "custom-package",
+  "version": "1.0.0",
+  "description": "",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+  }
+}

--- a/__tests__/include-dependencies.js
+++ b/__tests__/include-dependencies.js
@@ -176,3 +176,63 @@ test('getDependencies should return an array', t => {
   t.true(Array.isArray(dependencies));
   t.true(dependencies.length > 0);
 });
+
+test('dependencies with no main file should fail', t => {
+  t.throws(() => {
+    const instance = createTestInstance();
+    const directory = path.join(__dirname, 'fixtures');
+    const file = path.join(directory, 'thing-2.js');
+    instance.getDependencies(file, directory);
+  });
+});
+
+test('package with no main file should pass when filtered', t => {
+    const instance = createTestInstance({
+      service: {
+        custom: {
+          'serverless-plugin-include-dependencies': {
+            'custom-package': 'custom.js'
+          }
+        }
+      }
+    });
+    const directory = path.join(__dirname, 'fixtures');
+    const file = path.join(directory, 'custom-direct-dependency.js');
+    const dependencies = instance.getDependencies(file, directory);
+    t.true(Array.isArray(dependencies));
+    t.true(dependencies.length > 0);
+})
+
+test('dependencies with no main file should pass when filtered', t => {
+    const instance = createTestInstance({
+      service: {
+        custom: {
+          'serverless-plugin-include-dependencies': {
+            'custom-package': 'custom.js'
+          }
+        }
+      }
+    });
+    const directory = path.join(__dirname, 'fixtures');
+    const file = path.join(directory, 'custom-dependency.js');
+    const dependencies = instance.getDependencies(file, directory);
+    t.true(Array.isArray(dependencies));
+    t.true(dependencies.length > 0);
+})
+
+test('optional dependencies with no main file should pass when filtered', t => {
+    const instance = createTestInstance({
+      service: {
+        custom: {
+          'serverless-plugin-include-dependencies': {
+            'custom-package': 'custom.js'
+          }
+        }
+      }
+    });
+    const directory = path.join(__dirname, 'fixtures');
+    const file = path.join(directory, 'custom-optional-dependency.js');
+    const dependencies = instance.getDependencies(file, directory);
+    t.true(Array.isArray(dependencies));
+    t.true(dependencies.length > 0);
+})

--- a/include-dependencies.js
+++ b/include-dependencies.js
@@ -15,6 +15,13 @@ module.exports = class IncludeDependencies {
     }
     this.serverless = serverless;
     this.options = options;
+
+    this.filterDeps = {};
+    if (serverless.service.custom &&
+      serverless.service.custom['serverless-plugin-include-dependencies']) {
+        this.filterDeps = serverless.service.custom['serverless-plugin-include-dependencies'];
+    }
+
     this.hooks = {
       'before:deploy:function:deploy': this.functionDeploy.bind(this),
       'before:deploy:createDeploymentArtifacts': this.createDeploymentArtifacts.bind(this)
@@ -58,7 +65,7 @@ module.exports = class IncludeDependencies {
   }
 
   getDependencies(fileName) {
-    return getDependencyList(fileName, this.serverless);
+    return getDependencyList(fileName, this.serverless, this.filterDeps);
   }
 
   include(target, paths) {


### PR DESCRIPTION
…n index.js or specify main.

What's happening in some libraries is that their structure doesn't conform in a way that `resolve` can recognize (an example is babel-runtime). They don't have an index.js file or a specified entry 'main' file in their package.json. I've added this so that you can specify an entry point for these kind of libraries if you need to use them. 