### PR TITLE
Include only base name of dependencies

### DIFF
--- a/__tests__/fixtures/dep-file.js
+++ b/__tests__/fixtures/dep-file.js
@@ -1,0 +1,1 @@
+require('test-dep/file');

--- a/__tests__/fixtures/node_modules/@test/scoped-dep/package.json
+++ b/__tests__/fixtures/node_modules/@test/scoped-dep/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@test/scoped-dep",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC"
+}

--- a/__tests__/fixtures/node_modules/test-dep/package.json
+++ b/__tests__/fixtures/node_modules/test-dep/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "test-dep",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC"
+}

--- a/__tests__/fixtures/scoped-dep-file.js
+++ b/__tests__/fixtures/scoped-dep-file.js
@@ -1,0 +1,1 @@
+require('@test/scoped-dep/file');

--- a/__tests__/get-dependency-list.js
+++ b/__tests__/get-dependency-list.js
@@ -40,3 +40,19 @@ test('should include packages with no main', (t) => {
   t.true(list.some(item => item.match(/babel-runtime/)));
   t.true(list.some(item => item.match(/babel-polyfill/)));
 });
+
+test('handles requiring dependency file', (t) => {
+	const fileName = path.join(__dirname, 'fixtures', 'dep-file.js');
+
+	const list = getDependencyList(fileName);
+
+	t.true(list.some(item => item.match(/test-dep/)));
+});
+
+test('handles requiring dependency file in scoped package', (t) => {
+	const fileName = path.join(__dirname, 'fixtures', 'scoped-dep-file.js');
+
+	const list = getDependencyList(fileName);
+
+	t.true(list.some(item => item.match(/@test\/scoped-dep/)));
+});

--- a/get-dependency-list.js
+++ b/get-dependency-list.js
@@ -5,6 +5,7 @@ const path = require('path');
 const precinct = require('precinct');
 const resolve = require('resolve');
 const resolvePkg = require('resolve-pkg');
+const requirePackageName = require('require-package-name');
 
 module.exports = function(filename, serverless) {
   const base = path.dirname(filename);
@@ -31,12 +32,8 @@ module.exports = function(filename, serverless) {
         });
         filesToProcess.push(abs);
       } else {
-        const numBaseTokens = name.indexOf('@') === 0 ? 2 : 1;
-        const tokens = name.split('/');
-        if (tokens.length > numBaseTokens) {
-          name = tokens.slice(0, numBaseTokens).join('/');
-        }
-        const path = resolvePkg(name, {
+        const moduleName = requirePackageName(name.replace(/\\/, '/'));
+        const path = resolvePkg(moduleName, {
           cwd: base
         });
 

--- a/get-dependency-list.js
+++ b/get-dependency-list.js
@@ -31,9 +31,10 @@ module.exports = function(filename, serverless) {
         });
         filesToProcess.push(abs);
       } else {
+        const numBaseTokens = name.indexOf('@') === 0 ? 2 : 1;
         const tokens = name.split('/');
-        if (tokens.length > 2) {
-          name = tokens.slice(0,2).join('/');
+        if (tokens.length > numBaseTokens) {
+          name = tokens.slice(0, numBaseTokens).join('/');
         }
         const path = resolvePkg(name, {
           cwd: base

--- a/get-dependency-list.js
+++ b/get-dependency-list.js
@@ -31,6 +31,10 @@ module.exports = function(filename, serverless) {
         });
         filesToProcess.push(abs);
       } else {
+        const tokens = name.split('/');
+        if (tokens.length > 2) {
+          name = tokens.slice(0,2).join('/');
+        }
         const path = resolvePkg(name, {
           cwd: base
         });

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "precinct": "3.6.0",
+    "require-package-name": "2.0.1",
     "resolve": "1.3.2",
     "resolve-pkg": "1.0.0",
     "semver": "5.3.0"


### PR DESCRIPTION
Fixes error when requiring a file of a dependency. Eg. `require('dep/file')` used to result in Serverless error:
```
Error --------------------------------------------------
     Cannot find module '/path/dep/file/package.json'
```