### PR TITLE
get the dependencies for includes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ package:
 plugins:
   - serverless-plugin-include-dependencies
 
+custom:
+  includeDependencies:
+    always:
+      - 'src/lib/**' # (optional) always include these globs and their dependencies
+
 functions:
   foo:
     handler: src/handler/foo.handler

--- a/__tests__/fixtures/api/dynamic-required.js
+++ b/__tests__/fixtures/api/dynamic-required.js
@@ -1,0 +1,2 @@
+require('test-dep');
+require('core-js');

--- a/__tests__/fixtures/api/handler.js
+++ b/__tests__/fixtures/api/handler.js
@@ -1,0 +1,1 @@
+require('@test/scoped-dep');

--- a/__tests__/include-dependencies.js
+++ b/__tests__/include-dependencies.js
@@ -120,6 +120,112 @@ test('processFunction should add to package include', t => {
   ]);
 });
 
+test('processFunction should add "always" globs and their dependencies to package include', t => {
+  const instance = createTestInstance({
+    service: {
+      package: {
+        exclude: ['node_modules/**/core-js/**']
+      },
+      custom: {
+        includeDependencies: {
+          always: ['api/**']
+        }
+      },
+    }
+  });
+
+  sinon.stub(instance, 'getHandlerFilename', () => path.join(__dirname, 'fixtures', 'api', 'handler.js'));
+
+  instance.processFunction('a');
+
+  t.deepEqual(instance.serverless.service.package.include, [
+    'api/**',
+    'api/dynamic-required.js',
+    'node_modules/test-dep/package.json',
+    'node_modules/test-dep/test-dep.js',
+    'api/handler.js',
+    'node_modules/@test/scoped-dep/package.json',
+  ]);
+});
+
+test('processFunction should add "always" globs and their dependencies to function include with package options', t => {
+  const instance = createTestInstance({
+    service: {
+      package: {
+        individually: true,
+        include: ['.something']
+      },
+      custom: {
+        includeDependencies: {
+          always: ['api/**']
+        }
+      },
+      functions: {
+        a: {
+          package: {
+            exclude: ['node_modules/**/core-js/**']
+          }
+        }
+      }
+    }
+  });
+
+  sinon.stub(instance, 'getHandlerFilename', () => path.join(__dirname, 'fixtures', 'api', 'handler.js'));
+
+  instance.processFunction('a');
+
+  t.deepEqual(instance.serverless.service.package.include, [
+    '.something'
+  ]);
+
+  t.deepEqual(instance.serverless.service.functions.a.package.include, [
+    'api/**',
+    'api/dynamic-required.js',
+    'node_modules/test-dep/package.json',
+    'node_modules/test-dep/test-dep.js',
+    'api/handler.js',
+    'node_modules/@test/scoped-dep/package.json',
+  ]);
+});
+
+test('processFunction should add "always" globs and their dependencies to function include without package options', t => {
+  const instance = createTestInstance({
+    service: {
+      package: {
+        individually: true,
+        include: ['.something'],
+        exclude: ['node_modules/**/core-js/**']
+      },
+      custom: {
+        includeDependencies: {
+          always: ['api/**']
+        }
+      },
+      functions: {
+        a: {
+        }
+      }
+    }
+  });
+
+  sinon.stub(instance, 'getHandlerFilename', () => path.join(__dirname, 'fixtures', 'api', 'handler.js'));
+
+  instance.processFunction('a');
+
+  t.deepEqual(instance.serverless.service.package.include, [
+    '.something'
+  ]);
+
+  t.deepEqual(instance.serverless.service.functions.a.package.include, [
+    'api/**',
+    'api/dynamic-required.js',
+    'node_modules/test-dep/package.json',
+    'node_modules/test-dep/test-dep.js',
+    'api/handler.js',
+    'node_modules/@test/scoped-dep/package.json',
+  ]);
+});
+
 test('processFunction should include individually', t => {
   const instance = createTestInstance({
     service: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-plugin-include-dependencies",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "engines": {
     "node": ">=4.0"
   },


### PR DESCRIPTION
These are the changes I was thinking about, to go through the includes and find dependencies which might not be statically required.

In my project this adds a fair amount of processing time, so I'm thinking we should probably have a default-off option to enable this.