### PR TITLE
feat: allow local dependencies 

### DIFF
--- a/__tests__/fixtures/dep-local-named.js
+++ b/__tests__/fixtures/dep-local-named.js
@@ -1,0 +1,1 @@
+require('local/named');

--- a/__tests__/get-dependency-list.js
+++ b/__tests__/get-dependency-list.js
@@ -125,3 +125,11 @@ test('throws on missing peerDependencies', (t) => {
   t.is(error.message, '[serverless-plugin-include-dependencies]: Could not find wont-find-me');
 });
 
+test('understands local named dependencies', (t) => {
+  const fileName = path.join(__dirname, 'fixtures', 'dep-local-named.js');
+
+  const list = getDependencyList(fileName, serverless);
+
+  t.true(list.some(item => item.endsWith('dep-local-named.js')));
+  t.true(list.some(item => item.endsWith('local/named/index.js')));
+});

--- a/get-dependency-list.js
+++ b/get-dependency-list.js
@@ -43,7 +43,14 @@ module.exports = function(filename, serverless) {
           serverless.cli.log(`[serverless-plugin-include-dependencies]: WARNING missing optional dependency: ${moduleName}`);
           return null;
         }
-        throw new Error(`[serverless-plugin-include-dependencies]: Could not find ${moduleName}`);
+        try {
+          // this resolves the requested import also against any set up NODE_PATH extensions, etc.
+          const resolved = require.resolve(name);
+          localFilesToProcess.push(resolved);
+          return;
+        } catch(e) {
+          throw new Error(`[serverless-plugin-include-dependencies]: Could not find ${moduleName}`);
+        }
       }
       throw e;
     }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   ],
   "main": "include-dependencies.js",
   "scripts": {
-    "test": "nyc --all ava",
+    "test": "NODE_PATH=\"__tests__/fixtures/additional_node_path:${NODE_PATH:-}\" nyc --all ava",
     "posttest": "eslint .",
     "preversion": "update contributors",
     "prepublish": "git push origin master; git push origin --tags"


### PR DESCRIPTION
This change allows us to use local dependencies. They can be used when multiple source roots are defined via `NODE_PATH` for example.
Currently, the plugin incorrectly assumes that anything not starting with `./` or not resolved against the cwd is a module dependency.

references https://github.com/dougmoscrop/serverless-plugin-include-dependencies/issues/14 and https://github.com/dougmoscrop/serverless-plugin-include-dependencies/issues/23

Happy to add an example and tests if this change is accepted.