### PR TITLE
fix bug at getHandlerFilename if not dot in string

### DIFF
--- a/include-dependencies.js
+++ b/include-dependencies.js
@@ -130,7 +130,8 @@ module.exports = class IncludeDependencies {
   }
 
   getHandlerFilename(handler) {
-    const handlerPath = handler.slice(0, handler.lastIndexOf('.'));
+    const lastDotIndex = handler.lastIndexOf('.');
+    const handlerPath = handler.slice(0, lastDotIndex !== -1 ? lastDotIndex : 0);
     return require.resolve((path.join(this.serverless.config.servicePath, handlerPath)));
   }
 


### PR DESCRIPTION
Linked issue: https://github.com/dougmoscrop/serverless-plugin-include-dependencies/issues/33