### PR TITLE
Stop the aws-sdk exclusion

### DIFF
--- a/__tests__/get-dependency-list.js
+++ b/__tests__/get-dependency-list.js
@@ -83,31 +83,6 @@ test('should handle requires to a missing optionalDependency listed in dependenc
   t.true(log.called);
 });
 
-test('should handle requires with aws-sdk -- when missing', (t) => {
-  const fileName = path.join(__dirname, 'fixtures', 'missing-aws-sdk', 'entry.js');
-
-  const list = getDependencyList(fileName, serverless);
-
-  t.true(list.some(item => item.indexOf(`entry.js`) !== -1));
-});
-
-test('should handle requires with aws-sdk -- ignores when missing', (t) => {
-  const fileName = path.join(__dirname, 'fixtures', 'missing-aws-sdk', 'entry.js');
-
-  const list = getDependencyList(fileName, serverless);
-
-  t.true(list.some(item => item.indexOf(`entry.js`) !== -1));
-});
-
-test('should handle requires with aws-sdk -- does not include when found', (t) => {
-  const fileName = path.join(__dirname, 'fixtures', 'finds-aws-sdk', 'entry.js');
-
-  const list = getDependencyList(fileName, serverless);
-
-  t.true(list.some(item => item.indexOf(`entry.js`) !== -1));
-  t.false(list.some(item => item.indexOf(`fail-if-found.js`) !== -1));
-});
-
 test('includes a dependency with peerDependencies', (t) => {
   const fileName = path.join(__dirname, 'fixtures', 'dep-with-peer.js');
 

--- a/get-dependency-list.js
+++ b/get-dependency-list.js
@@ -8,10 +8,8 @@ const readPkgUp = require('read-pkg-up');
 const requirePackageName = require('require-package-name');
 const glob = require('glob');
 
-const alwaysIgnored = new Set(['aws-sdk']);
-
 function ignoreMissing(dependency, optional) {
-  return alwaysIgnored.has(dependency) || (optional && dependency in optional);
+  return optional && dependency in optional;
 }
 
 module.exports = function(filename, serverless) {
@@ -25,10 +23,6 @@ module.exports = function(filename, serverless) {
 
   function handle(name, basedir, optionalDependencies) {
     const moduleName = requirePackageName(name.replace(/\\/, '/'));
-
-    if (alwaysIgnored.has(moduleName)) {
-      return;
-    }
 
     try {
       const pathToModule = resolve.sync(path.join(moduleName, 'package.json'), { basedir });


### PR DESCRIPTION
AWS-SDK should be treated as a normal dependency, _even if it's already available on the AWS Lambda environment_.

Something might just break when AWS decides to upgrade the SDK version, without any warning.

From the official AWS docs:
_We recommend including your own copy of the AWS SDK for production applications so you can control your dependencies._
https://docs.aws.amazon.com/lambda/latest/dg/accessing-resources.html

Fixes https://github.com/dougmoscrop/serverless-plugin-include-dependencies/issues/36