### PR TITLE
Use caching to reduce redundant work

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,17 @@ package:
 ```
 But be warned: Smaller individual functions can still mean a larger overall deployment. (10 functions that are 3 MB each is more net data tranfer and storage than 1 function that is 6 MB)
 
+## Dependency caching (Experimental)
+
+When building a shared bundle for several functions, execution time can be reduced by enabling dependency caching. Caching is disabled by default and can be enabled using the `enableCaching` option:
+
+```yaml
+custom:
+  includeDependencies:
+    enableCaching: true
+```
+
+
 ## New In 2.0 - Exclusion Support
 
 Rather than including module folders (e.g. `node_modules/foo/**`, it now includes a list of actual files (e.g. `node_modules/foo/package.json`, `node_modules/foo/index.js`) and *uses the serverless package exclude* to filter these files. Excludes *must* start with `node_modules` to be considered by this plugin.

--- a/__tests__/fixtures/bar/index.js
+++ b/__tests__/fixtures/bar/index.js
@@ -1,1 +1,2 @@
+require('../babel');
 module.exports = require('./baz');

--- a/__tests__/fixtures/dep-local-named-2.js
+++ b/__tests__/fixtures/dep-local-named-2.js
@@ -1,1 +1,0 @@
-require('local/named');

--- a/__tests__/fixtures/dep-local-named-2.js
+++ b/__tests__/fixtures/dep-local-named-2.js
@@ -1,0 +1,1 @@
+require('local/named');

--- a/__tests__/fixtures/foo/index.js
+++ b/__tests__/fixtures/foo/index.js
@@ -1,1 +1,2 @@
+require('../babel');
 module.exports = require('./baz');

--- a/__tests__/fixtures/redundancies-1.js
+++ b/__tests__/fixtures/redundancies-1.js
@@ -1,0 +1,3 @@
+require('local/named');
+require('./other/other-thing');
+require('./symlinked/symlinked');

--- a/__tests__/fixtures/redundancies-2.js
+++ b/__tests__/fixtures/redundancies-2.js
@@ -1,0 +1,3 @@
+require('local/named');
+require('./thing');
+require('test-dep');

--- a/__tests__/fixtures/symlinked/node_modules/test-dep
+++ b/__tests__/fixtures/symlinked/node_modules/test-dep
@@ -1,0 +1,1 @@
+../../node_modules/test-dep/

--- a/__tests__/fixtures/symlinked/package.json
+++ b/__tests__/fixtures/symlinked/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "sample",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "test-dep": "*"
+  }
+}

--- a/__tests__/fixtures/symlinked/symlinked.js
+++ b/__tests__/fixtures/symlinked/symlinked.js
@@ -1,0 +1,1 @@
+require('test-dep');

--- a/__tests__/get-dependency-list.js
+++ b/__tests__/get-dependency-list.js
@@ -119,3 +119,17 @@ test('understands local named dependencies', (t) => {
   t.true(list.some(item => item.endsWith('dep-local-named.js')));
   t.true(list.some(item => item.endsWith('local/named/index.js')));
 });
+
+test('caches lookups', (t) => {
+  const fileName = path.join(__dirname, 'fixtures', 'dep-local-named.js');
+  const fileName2 = path.join(__dirname, 'fixtures', 'dep-local-named-2.js');
+
+  const cache = new Set();
+  const list1 = getDependencyList(fileName, serverless, cache);
+  const list2 = getDependencyList(fileName2, serverless, cache);
+
+  t.true(list1.some(item => item.endsWith('dep-local-named.js')));
+  t.true(list1.some(item => item.endsWith('local/named/index.js')));
+  t.true(list2.some(item => item.endsWith('dep-local-named-2.js')));
+  t.false(list2.some(item => item.endsWith('local/named/index.js')));
+});

--- a/__tests__/get-dependency-list.js
+++ b/__tests__/get-dependency-list.js
@@ -121,15 +121,18 @@ test('understands local named dependencies', (t) => {
 });
 
 test('caches lookups', (t) => {
-  const fileName = path.join(__dirname, 'fixtures', 'dep-local-named.js');
-  const fileName2 = path.join(__dirname, 'fixtures', 'dep-local-named-2.js');
+  const fileName = path.join(__dirname, 'fixtures', 'redundancies-1.js');
+  const fileName2 = path.join(__dirname, 'fixtures', 'redundancies-2.js');
 
   const cache = new Set();
   const list1 = getDependencyList(fileName, serverless, cache);
   const list2 = getDependencyList(fileName2, serverless, cache);
 
-  t.true(list1.some(item => item.endsWith('dep-local-named.js')));
   t.true(list1.some(item => item.endsWith('local/named/index.js')));
-  t.true(list2.some(item => item.endsWith('dep-local-named-2.js')));
+  t.true(list1.some(item => item.endsWith('symlinked.js')));
+  t.true(list1.some(item => item.endsWith('node_modules/test-dep/test-dep.js')));
+
   t.false(list2.some(item => item.endsWith('local/named/index.js')));
+  t.false(list2.some(item => item.endsWith('symlinked.js')));
+  t.false(list2.some(item => item.endsWith('test-dep.js')));
 });

--- a/__tests__/include-dependencies.js
+++ b/__tests__/include-dependencies.js
@@ -415,3 +415,21 @@ test('processFunction should handle different runtimes', t => {
 
   t.true(processNode.calledTwice);
 });
+
+test('disables caching by default', t => {
+  const instance = createTestInstance();
+  const file = path.join(__dirname, 'fixtures', 'thing.js');
+  const list1 = instance.getDependencies(file, []);
+  const list2 = instance.getDependencies(file, []);
+  t.deepEqual(list1, list2);
+});
+
+test('enables caching', t => {
+  const instance = createTestInstance({
+    service: { custom: { includeDependencies: { enableCaching: true } } }
+  });
+  const file = path.join(__dirname, 'fixtures', 'thing.js');
+  const list1 = instance.getDependencies(file, []);
+  const list2 = instance.getDependencies(file, []);
+  t.true(list2.length < list1.length);
+});

--- a/get-dependency-list.js
+++ b/get-dependency-list.js
@@ -22,13 +22,10 @@ module.exports = function(filename, serverless, cache) {
 
   function handle(name, basedir, optionalDependencies, peerDependenciesMeta) {
     const moduleName = requirePackageName(name.replace(/\\/, '/'));
+    const cacheKey = `${basedir}:${name}`;
 
-    if (cache) {
-      const cacheKey = `${basedir}:${name}`;
-      if (cache.has(cacheKey)) {
-        return;
-      }
-      cache.add(cacheKey);
+    if (cache && cache.has(cacheKey)) {
+      return;
     }
 
     try {
@@ -37,6 +34,11 @@ module.exports = function(filename, serverless, cache) {
 
       if (pkg) {
         modulesToProcess.push(pkg);
+
+        if (cache) {
+          cache.add(cacheKey);
+        }
+  
       } else {
         // TODO: should we warn here?
       }
@@ -50,6 +52,11 @@ module.exports = function(filename, serverless, cache) {
           // this resolves the requested import also against any set up NODE_PATH extensions, etc.
           const resolved = require.resolve(name);
           localFilesToProcess.push(resolved);
+
+          if (cache) {
+            cache.add(cacheKey);
+          }
+
           return;
         } catch(e) {
           throw new Error(`[serverless-plugin-include-dependencies]: Could not find ${moduleName}`);

--- a/get-dependency-list.js
+++ b/get-dependency-list.js
@@ -13,22 +13,23 @@ function ignoreMissing(dependency, optional, peerDependenciesMeta) {
     || peerDependenciesMeta && dependency in peerDependenciesMeta && peerDependenciesMeta[dependency].optional;
 }
 
-module.exports = function(filename, serverless, _cache) {
+module.exports = function(filename, serverless, cache) {
   const servicePath = serverless.config.servicePath;
   const modulePaths = new Set();
   const filePaths = new Set();
-  const cache = _cache || new Set();
   const modulesToProcess = [];
   const localFilesToProcess = [filename];
 
   function handle(name, basedir, optionalDependencies, peerDependenciesMeta) {
     const moduleName = requirePackageName(name.replace(/\\/, '/'));
 
-    if (cache.has(`${basedir}:${name}`)) {
-      return;
+    if (cache) {
+      const cacheKey = `${basedir}:${name}`;
+      if (cache.has(cacheKey)) {
+        return;
+      }
+      cache.add(cacheKey);
     }
-
-    cache.add(`${basedir}:${name}`);
 
     try {
       const pathToModule = resolve.sync(path.join(moduleName, 'package.json'), { basedir });

--- a/get-dependency-list.js
+++ b/get-dependency-list.js
@@ -13,17 +13,22 @@ function ignoreMissing(dependency, optional, peerDependenciesMeta) {
     || peerDependenciesMeta && dependency in peerDependenciesMeta && peerDependenciesMeta[dependency].optional;
 }
 
-module.exports = function(filename, serverless) {
+module.exports = function(filename, serverless, _cache) {
   const servicePath = serverless.config.servicePath;
-
-  const filePaths = new Set();
   const modulePaths = new Set();
-
+  const filePaths = new Set();
+  const cache = _cache || new Set();
   const modulesToProcess = [];
   const localFilesToProcess = [filename];
 
   function handle(name, basedir, optionalDependencies, peerDependenciesMeta) {
     const moduleName = requirePackageName(name.replace(/\\/, '/'));
+
+    if (cache.has(`${basedir}:${name}`)) {
+      return;
+    }
+
+    cache.add(`${basedir}:${name}`);
 
     try {
       const pathToModule = resolve.sync(path.join(moduleName, 'package.json'), { basedir });

--- a/include-dependencies.js
+++ b/include-dependencies.js
@@ -23,7 +23,7 @@ module.exports = class IncludeDependencies {
 
     this.serverless = serverless;
     this.options = options;
-    this.globalCache = new Set();
+    this.cache = new Set();
 
     const service = this.serverless.service;
     this.individually = service.package && service.package.individually;
@@ -153,12 +153,16 @@ module.exports = class IncludeDependencies {
   }
 
   getDependencyList(fileName) {
-    const cache = this.individually ? new Set() : this.globalCache;
-    return getDependencyList(fileName, this.serverless, cache);
+    if (!this.individually) {
+      const options = this.getPluginOptions();
+      if (options && options.enableCaching) {
+        return getDependencyList(fileName, this.serverless, this.cache);
+      }
+    }
+    return getDependencyList(fileName, this.serverless);
   }
 
   include(target, dependencies) {
     target.package.include = union(target.package.include, dependencies);
   }
-
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-plugin-include-dependencies",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-plugin-include-dependencies",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "engines": {
     "node": ">=4.0"
   },


### PR DESCRIPTION
This will speed things up when building combined packages. Without these changes the plugin recomputes dependencies for the same files/modules over and over so packaging times can get quite long if you have a lot of functions and/or use "include: always".

I'm also not sure when the logic in serverless changed, but [this code](https://github.com/serverless/serverless/blob/master/lib/plugins/package/lib/packageService.js#L249) goes through every file in the project (including things like .git/**) and compares the file list against the include/exclude list. It's a complete waste of time when using this plugin, so I added this in our serverless.yml to work around it:

```yaml
package:
  include:
    - '!**'
```

I'm wondering if this plugin should add `!**` to the include list by default. Or I could at least add a note to the readme.
