### PR TITLE
Improve error message for missing npm dependency

### DIFF
--- a/__tests__/get-dependency-list.js
+++ b/__tests__/get-dependency-list.js
@@ -108,7 +108,7 @@ test('throws on missing peerDependencies', (t) => {
 
   const error = t.throws(() => getDependencyList(fileName, serverless));
 
-  t.is(error.message, '[serverless-plugin-include-dependencies]: Could not find wont-find-me');
+  t.is(error.message, '[serverless-plugin-include-dependencies]: Could not find npm package: wont-find-me');
 });
 
 test('understands local named dependencies', (t) => {

--- a/get-dependency-list.js
+++ b/get-dependency-list.js
@@ -59,7 +59,7 @@ module.exports = function(filename, serverless, cache) {
 
           return;
         } catch(e) {
-          throw new Error(`[serverless-plugin-include-dependencies]: Could not find ${moduleName}`);
+          throw new Error(`[serverless-plugin-include-dependencies]: Could not find npm package: ${moduleName}`);
         }
       }
       throw e;


### PR DESCRIPTION
Improves error message to add more context in order to avoid confusions like in #58.