### PR TITLE
add including files that need their requires checked

### DIFF
--- a/__tests__/get-dependency-list.js
+++ b/__tests__/get-dependency-list.js
@@ -13,7 +13,7 @@ const serverless = {
 };
 
 function convertSlashes(paths) {
-  return paths.map(name => name.replaceAll('\\\\', '/')).map(name => name.replaceAll('\\', '/'));
+  return paths.map(name => name.replaceAll('\\', '/'));
 }
 
 test('includes a deep dependency', (t) => {

--- a/__tests__/get-dependency-list.js
+++ b/__tests__/get-dependency-list.js
@@ -12,6 +12,10 @@ const serverless = {
   }
 };
 
+function convertSlashes(paths) {
+  return paths.map(name => name.replaceAll('\\\\', '/')).map(name => name.replaceAll('\\', '/'));
+}
+
 test('includes a deep dependency', (t) => {
   const fileName = path.join(__dirname, 'fixtures', 'thing.js');
 
@@ -66,7 +70,7 @@ test('handles requiring dependency file in scoped package', (t) => {
 test('should handle requires with same relative path but different absolute path', (t) => {
   const fileName = path.join(__dirname, 'fixtures', 'same-relative-require.js');
 
-  const list = getDependencyList(fileName, serverless);
+  const list = convertSlashes(getDependencyList(fileName, serverless));
 
   t.true(list.some(item => item.indexOf(`bar/baz.js`) !== -1));
   t.true(list.some(item => item.indexOf(`foo/baz.js`) !== -1));
@@ -125,8 +129,9 @@ test('caches lookups', (t) => {
   const fileName2 = path.join(__dirname, 'fixtures', 'redundancies-2.js');
 
   const cache = new Set();
-  const list1 = getDependencyList(fileName, serverless, cache);
-  const list2 = getDependencyList(fileName2, serverless, cache);
+  const checkedFiles = new Set();
+  const list1 = getDependencyList(fileName, serverless, checkedFiles, cache);
+  const list2 = getDependencyList(fileName2, serverless, checkedFiles, cache);
 
   t.true(list1.some(item => item.endsWith('local/named/index.js')));
   t.true(list1.some(item => item.endsWith('symlinked.js')));

--- a/__tests__/include-dependencies.js
+++ b/__tests__/include-dependencies.js
@@ -9,10 +9,10 @@ const sinon = require('sinon');
 const IncludeDependencies = require('../include-dependencies.js');
 
 function convertSlashes(paths) {
-  return paths.map(name => name.replaceAll('\\\\', '/')).map(name => name.replaceAll('\\', '/'));
+  return paths.map(name => name.replaceAll('\\', '/'));
 }
 
-function createTestInstance(serverless, options) {
+function createTestInstance(serverless, options, functions = {a: {}, b: {}}) {
   return new IncludeDependencies(
     _.merge({
       version: '2.32.0',
@@ -20,10 +20,7 @@ function createTestInstance(serverless, options) {
         servicePath: path.join(__dirname, 'fixtures')
       },
       service: {
-        functions: {
-          a: {},
-          b: {}
-        }
+        functions
       }
     }, serverless),
     _.merge({}, options)
@@ -73,7 +70,7 @@ test('createDeploymentArtifacts should call processFunction with function name',
 });
 
 test('createDeploymentArtifacts should call getDependencies for patterns files', t => {
-  const fileName = path.join(__dirname, 'fixtures', 'thing.js');
+  const fileName = path.join(__dirname, 'fixtures', 'thing.js').replaceAll('\\', '/');
   const instance = createTestInstance({
     service: {
       provider: {
@@ -128,34 +125,6 @@ test('processFunction should add node_modules ignore to package patterns', t => 
 });
 
 test('processFunction should add to package include', t => {
-  const instance = createTestInstance({
-    service: {
-      provider: {
-        runtime: 'nodejs14.x',
-      },
-      package: {
-        patterns: ['.something']
-      }
-    }
-  });
-
-  sinon.stub(instance, 'getHandlerFilename').returns('handler.js');
-  sinon.stub(instance, 'getDependencies').returns([
-    path.join('node_modules', 'brightspace-auth-validation', 'index.js'),
-    path.join('node_modules', 'brightspace-auth-validation', 'node_modules', 'jws', 'index.js'),
-  ]);
-
-  instance.processFunction('a');
-
-  t.deepEqual(convertSlashes(instance.serverless.service.package.patterns), [
-    '!node_modules/**',
-    '.something',
-    'node_modules/brightspace-auth-validation/index.js',
-    'node_modules/brightspace-auth-validation/node_modules/jws/index.js'
-  ]);
-});
-
-test('processFunction should import for patterns', t => {
   const instance = createTestInstance({
     service: {
       provider: {

--- a/include-dependencies.js
+++ b/include-dependencies.js
@@ -62,7 +62,7 @@ module.exports = class IncludeDependencies {
           ignore: path.join(modulePath, 'node_modules', '**'),
           absolute: true
         })
-      ).flat().map(file => file.replaceAll('/', "\\")))];
+      ).flat().map(file => file.replaceAll('\\', '/')))];
 
     files.forEach(fileName => {
       if (!this.checkedFiles.has(fileName)) {


### PR DESCRIPTION
This is a very naive way to approach what I think needs to be done, but it works.

I didn't want to mess with the patterns in the `serverless.yml`, so I've added another var that can be in package called `includeRequires`. I've also updated the code I was attempting to deploy to have this variable.
https://github.com/Brightspace/discovery-bff/pull/437