### PR TITLE
feat: add handlerRoot plugin config

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,17 @@ custom:
   includeDependencies:
     enableCaching: true
 ```
+## Monorepo
+
+When building outputs to root directory in a monorepo for instance while using nest-cli, you end up with outputs in `root/dist/app-name`, 
+this is not how serverless-compose wants it. by default the `this.serverless.config.servicePath` will be the path of app you are building.
+Because of that this plugin will not find the handler, you can support this by adding the following
+
+```yaml
+custom:
+  includeDependencies:
+    handlerRoot: ../../
+```
 
 ## New In 2.0 - Exclusion Support
 

--- a/include-dependencies.js
+++ b/include-dependencies.js
@@ -134,7 +134,10 @@ module.exports = class IncludeDependencies {
   getHandlerFilename(handler) {
     const lastDotIndex = handler.lastIndexOf('.');
     const handlerPath = lastDotIndex !== -1 ? handler.slice(0, lastDotIndex) : 'index';
-    return require.resolve((path.join(this.serverless.config.servicePath, handlerPath)));
+
+    const path = this.getPluginOptions().handlerRoot || this.serverless.config.servicePath;
+
+    return require.resolve((path.join(path, handlerPath)));
   }
 
   getDependencies(fileName, patterns, useCache = false) {


### PR DESCRIPTION
When building outputs to root directory in a monorepo for instance while using nest-cli, you end up with outputs in `root/dist/app-name`, 
this is not how serverless-compose wants it. by default the `this.serverless.config.servicePath` will be the path of app you are building.

So in other words you get a failure because it is looking for

'root/apps/app-name/dist/app-name/main'

this allows to override this trough custom config