### PR TITLE
fix: loosen up exclusions a bit

### DIFF
--- a/__tests__/include-dependencies.js
+++ b/__tests__/include-dependencies.js
@@ -263,6 +263,26 @@ test('getDependencies should handle exclude of a file within a dependency', t =>
   t.true(dependencies.some(p => p.match(/readable-stream\/LICENSE/)));
 });
 
+test('getDependencies should handle excludes of root node_modules', t => {
+  const dependencyListStubReturn = [
+    path.join('node_modules', 'brightspace-auth-validation', 'index.js'),
+    path.join('node_modules', 'some-other', 'index.js'),
+  ];
+
+  const dependencyListStub = getDependencyListStub(dependencyListStubReturn);
+  const instance = createTestInstance({ dependencyListStub });
+  const file = path.join(__dirname, 'fixtures', 'thing.js');
+  const dependencies = instance.getDependencies(file, [
+    '!../../node_modules/brightspace-auth-validation/*'
+  ]);
+
+  t.true(Array.isArray(dependencies));
+  t.true(dependencies.length > 0);
+  
+  t.false(dependencies.some(p => p.match(/brightspace-auth-validation\/index.js/)));
+  t.true(dependencies.some(p => p.match(/some-other\/index.js/)));
+});
+
 test('getDependencies should ignore excludes that do not start with node_modules', t => {
   const instance = createTestInstance();
   const file = path.join(__dirname, 'fixtures', 'thing.js');

--- a/include-dependencies.js
+++ b/include-dependencies.js
@@ -145,9 +145,7 @@ module.exports = class IncludeDependencies {
     const dependencies = getDependencyList(fileName, this.serverless, useCache && this.cache) || [];
     const relativeDependencies = dependencies.map(p => path.relative(servicePath, p));
 
-    const exclusions = patterns.filter(p => {
-      return !(p.indexOf('!node_modules') !== 0 || p === '!node_modules' || p === '!node_modules/**');
-    });
+    const exclusions = patterns.filter(p => p.startsWith('!') && p.includes('node_modules'));
 
     if (exclusions.length > 0) {
       return micromatch(relativeDependencies, exclusions);


### PR DESCRIPTION
As we are using a monorepo setup and some of our packages are containing binaries which we needed to exclude, we found out that the current exclusions package filtering is a bit too strict

Our current layout

```
--Root
  -- node_modules
     -- package_to_exclude
  -- apps
     -- app-one
```

In our case our node_modules end up in `../../node_modules/package_to_exclude` which does not get excluded using minimatch because the filter for exclusions enforced either starting with `!node_modules`, equal to`!node_modules` or equal to `!node_modules/**`. So we can not exclude packages in our use-case

I've tried to loosen the restrictions a bit, so it can be used in both and probably more uses cases

Let me know if there is anything not ok with pull

Thx