### PR TITLE
Don't run `processNodeFunction` for functions without handlers

### DIFF
--- a/include-dependencies.js
+++ b/include-dependencies.js
@@ -93,7 +93,7 @@ module.exports = class IncludeDependencies {
     const functionObject = service.functions[functionName];
     const runtime = this.getFunctionRuntime(functionObject);
 
-    if (/(provided|nodejs)+/.test(runtime)) {
+    if (/(provided|nodejs)+/.test(runtime) && functionObject.handler) {
       this.processNodeFunction(functionObject);
     }
   }


### PR DESCRIPTION
Fix for https://github.com/dougmoscrop/serverless-plugin-include-dependencies/issues/100

edit: I made this PR and the (hidden) emails associated with my github account got signed up for a serverless email marketing list? wtf is this bullshit? last time I fix one of y'all's bugs 🖕